### PR TITLE
Github issues fixes

### DIFF
--- a/controls/V-92995.rb
+++ b/controls/V-92995.rb
@@ -48,6 +48,9 @@ control "V-92995" do
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
   os_type = command('Test-Path "$env:windir\explorer.exe"').stdout.strip
 
+# Test
+  puts disallowed_network_access_users
+
   if os_type == 'False'
     describe 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt' do
       skip 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt'

--- a/controls/V-92995.rb
+++ b/controls/V-92995.rb
@@ -48,11 +48,6 @@ control "V-92995" do
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
   os_type = command('Test-Path "$env:windir\explorer.exe"').stdout.strip
 
-# Test
-  describe disallowed_network_access_users do
-    it { should cmp [nil] }
-  end
-
   if os_type == 'False'
     describe 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt' do
       skip 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt'
@@ -68,7 +63,7 @@ control "V-92995" do
           unauthorized_users << user
         end
       end
-      describe "Network Access must be limited" do
+      describe "Network Logon Privilege must be limited" do
         it "Authorized SIDs: #{allowed_network_access_users}" do
           failure_message = "Unauthorized SIDs: #{unauthorized_users}"
           expect(unauthorized_users).to be_empty, failure_message

--- a/controls/V-92995.rb
+++ b/controls/V-92995.rb
@@ -63,7 +63,7 @@ control "V-92995" do
           unauthorized_users << user
         end
       end
-      describe "Network Logon Privilege must be limited" do
+      describe "Network Logon Privilege must be limited to" do
         it "Authorized SIDs: #{allowed_network_access_users}" do
           failure_message = "Unauthorized SIDs: #{unauthorized_users}"
           expect(unauthorized_users).to be_empty, failure_message

--- a/controls/V-92995.rb
+++ b/controls/V-92995.rb
@@ -49,7 +49,9 @@ control "V-92995" do
   os_type = command('Test-Path "$env:windir\explorer.exe"').stdout.strip
 
 # Test
-  puts disallowed_network_access_users
+  describe disallowed_network_access_users do
+    it { should cmp [nil] }
+  end
 
   if os_type == 'False'
     describe 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt' do

--- a/controls/V-93059.rb
+++ b/controls/V-93059.rb
@@ -62,7 +62,7 @@ control "V-93059" do
         unauthorized_users << user
       end
     end
-    describe "Global Object Creation Privilege must be limited" do
+    describe "Global Object Creation Privilege must be limited to" do
       it "Authorized SIDs: #{allowed_global_privilege_users}" do
         failure_message = "Unauthorized SIDs: #{unauthorized_users}"
         expect(unauthorized_users).to be_empty, failure_message

--- a/controls/V-93069.rb
+++ b/controls/V-93069.rb
@@ -56,7 +56,7 @@ control "V-93069" do
         unauthorized_users << user
       end
     end
-    describe "Security Audit Generation Privilege must be limited" do
+    describe "Security Audit Generation Privilege must be limited to" do
       it "Authorized SIDs: #{allowed_audit_privilege_users}" do
         failure_message = "Unauthorized SIDs: #{unauthorized_users}"
         expect(unauthorized_users).to be_empty, failure_message

--- a/inspec.yml
+++ b/inspec.yml
@@ -43,6 +43,20 @@ inputs:
     type: Numeric
     value: 3
 
+  - name: allowed_network_access_users
+    desc: "List SIDs of accounts that are authorized to have network access (SeNetworkLogonRight)"
+    type: Array
+    value:
+      - "S-1-5-32-544"
+      - "S-1-5-11"
+      - "S-1-5-9"
+
+  - name: disallowed_network_access_users
+    desc: "List SIDs of accounts that are not authorized to have network access (SeNetworkLogonRight)"
+    type: Array
+    value:
+      - 
+
   - name: c_perm
     desc: "Permissions on folder and file for C:\\ Directory"
     type: Array

--- a/inspec.yml
+++ b/inspec.yml
@@ -44,7 +44,7 @@ inputs:
     value: 3
 
   - name: allowed_network_access_users
-    desc: "List SIDs of accounts that are authorized to have network access (SeNetworkLogonRight)"
+    desc: "List SIDs of accounts that are authorized to have network logon user right (SeNetworkLogonRight)"
     type: Array
     value:
       - "S-1-5-32-544"
@@ -52,10 +52,25 @@ inputs:
       - "S-1-5-9"
 
   - name: disallowed_network_access_users
-    desc: "List SIDs of accounts that are not authorized to have network access (SeNetworkLogonRight)"
+    desc: "List SIDs of accounts that are not authorized to have network user right (SeNetworkLogonRight)"
     type: Array
     value:
       - 
+
+  - name: allowed_global_privilege_users
+    desc: "List SIDs of accounts that are authorized to have create global object user right (SeCreateGlobalPrivilege)"
+    type: Array
+    value:
+      - "S-1-5-32-544"
+      - "S-1-5-6"
+      - "S-1-5-19"
+      - "S-1-5-20"
+
+  - name: disallowed_global_privilege_users
+    desc: "List SIDs of accounts that are not authorized to have create global object user right (SeCreateGlobalPrivilege)"
+    type: Array
+    value:
+      -
 
   - name: c_perm
     desc: "Permissions on folder and file for C:\\ Directory"

--- a/inspec.yml
+++ b/inspec.yml
@@ -44,7 +44,7 @@ inputs:
     value: 3
 
   - name: allowed_network_access_users
-    desc: "List SIDs of accounts that are authorized to have network logon user right (SeNetworkLogonRight)"
+    desc: "List SIDs of accounts that are authorized to have the network logon user right (SeNetworkLogonRight)"
     type: Array
     value:
       - "S-1-5-32-544"
@@ -52,13 +52,13 @@ inputs:
       - "S-1-5-9"
 
   - name: disallowed_network_access_users
-    desc: "List SIDs of accounts that are not authorized to have network user right (SeNetworkLogonRight)"
+    desc: "List SIDs of accounts that are not authorized to the have network user right (SeNetworkLogonRight)"
     type: Array
     value:
       - 
 
   - name: allowed_global_privilege_users
-    desc: "List SIDs of accounts that are authorized to have create global object user right (SeCreateGlobalPrivilege)"
+    desc: "List SIDs of accounts that are authorized to have the create global object user right (SeCreateGlobalPrivilege)"
     type: Array
     value:
       - "S-1-5-32-544"
@@ -67,7 +67,20 @@ inputs:
       - "S-1-5-20"
 
   - name: disallowed_global_privilege_users
-    desc: "List SIDs of accounts that are not authorized to have create global object user right (SeCreateGlobalPrivilege)"
+    desc: "List SIDs of accounts that are not authorized to have the create global object user right (SeCreateGlobalPrivilege)"
+    type: Array
+    value:
+      -
+
+  - name: allowed_audit_privilege_users
+    desc: "List SIDs of accounts that are authorized to have the generate security audits user right (SeAuditPrivilege)"
+    type: Array
+    value:
+      - "S-1-5-19"
+      - "S-1-5-20"
+
+  - name: disallowed_audit_privilege_users
+    desc: "List SIDs of accounts that are not authorized to have the generate security audits user right (SeAuditPrivilege)"
     type: Array
     value:
       -


### PR DESCRIPTION
Fixes #7 
All controls except V-93073 have been modified. Reason: There are many other controls that are similar to V-93073 that have one default allowed SID, so the check expects the output to just have that one SID to pass the control. If this needs to be changed by following the approach of this PR, I can do it - please let me know what you think.

Fixes #9 
The error listed in the issue was based on older code that I modified in this [commit](https://github.com/mitre/microsoft-windows-server-2019-stig-baseline/commit/a7b957dc685771fedd53ba821aeef06e5c374545) to make it work. If you would like me to follow 2016 as Yarick has recommended, I can do that - please let me know what you think.

[Report](https://github.com/karikarshivani/InSpecReports/blob/master/Win2019IssuesFixFinal.json) based on this branch