### PR TITLE
fix typo related to reg_security_perms input

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -148,7 +148,7 @@ inputs:
     type: Array
     value:
       - NT AUTHORITY\SYSTEM Allow  FullControl
-      - BUILTIN\Administrators Allow  ReadKey, ChangePermissions
+      - BUILTIN\Administrators Allow  ReadPermissions, ChangePermissions
 
   - name: reg_system_perms
     desc: "The required Registry System Permissions Settings"

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,7 +5,7 @@ copyright: The Authors
 copyright_email: you@example.com
 license: Apache-2.0
 summary: "This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil."
-version: 1.3.2
+version: 1.3.3
 inspec_version: ">= 4.0"
 
 inputs:


### PR DESCRIPTION
The output of the test for HKLM:Security is:

```
(Get-Acl -Path HKLM:Security).AccessToString
NT AUTHORITY\SYSTEM Allow  FullControl
BUILTIN\Administrators Allow  ReadPermissions, ChangePermissions
```