### PR TITLE
modifications to better handle domain roles

### DIFF
--- a/controls/V-92965.rb
+++ b/controls/V-92965.rb
@@ -85,43 +85,48 @@ on through Remote Desktop Services\" to include the following:
   tag 'nist': ["AC-17 (1)", "Rev_4"]
 
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
-  is_domain = command('wmic computersystem get domain | FINDSTR /V Domain').stdout.strip
-  os_type = command('Test-Path "$env:windir\explorer.exe"').stdout.strip
-   if domain_role == '4' || domain_role == '5'
-      impact 0.0
-      desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
-        skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      end
-    elsif os_type == 'False'
-     describe 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt' do
-      skip 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt'
-     end
-    end 
-    if is_domain == 'WORKGROUP'
-        describe security_policy do
-         its('SeDenyRemoteInteractiveLogonRight') { should eq ['S-1-5-32-546'] }
-        end
-    else
-      domain_query = <<-EOH
-              $group = New-Object System.Security.Principal.NTAccount('Domain Admins')
-              $sid = ($group.Translate([security.principal.securityidentifier])).value
-              $sid | ConvertTo-Json
-              EOH
-
-      domain_admin_sid = json(command: domain_query).params
-      enterprise_admin_query = <<-EOH
-              $group = New-Object System.Security.Principal.NTAccount('Enterprise Admins')
-              $sid = ($group.Translate([security.principal.securityidentifier])).value
-              $sid | ConvertTo-Json
-              EOH
-
-      enterprise_admin_sid = json(command: enterprise_admin_query).params
-       describe security_policy do
-          its('SeDenyRemoteInteractiveLogonRight') { should include "#{domain_admin_sid}" }
-       end
-       describe security_policy do
-          its('SeDenyRemoteInteractiveLogonRight') { should include "#{enterprise_admin_sid}" }
-       end
+  case domain_role
+  when '4', '5'
+    impact 0.0
+    desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
+    describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
+      skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
     end
+  when '3'
+    domain_query = <<-EOH
+            $group = New-Object System.Security.Principal.NTAccount('Domain Admins')
+            $sid = ($group.Translate([security.principal.securityidentifier])).value
+            $sid | ConvertTo-Json
+            EOH
+
+    domain_admin_sid = json(command: domain_query).params
+    enterprise_admin_query = <<-EOH
+            $group = New-Object System.Security.Principal.NTAccount('Enterprise Admins')
+            $sid = ($group.Translate([security.principal.securityidentifier])).value
+            $sid | ConvertTo-Json
+            EOH
+
+    enterprise_admin_sid = json(command: enterprise_admin_query).params
+    describe security_policy do
+      its('SeDenyRemoteInteractiveLogonRight') { should include "#{domain_admin_sid}" }
+    end
+    describe security_policy do
+      its('SeDenyRemoteInteractiveLogonRight') { should include "#{enterprise_admin_sid}" }
+    end
+    describe.one do
+      describe security_policy do
+          its('SeDenyRemoteInteractiveLogonRight') { should include "S-1-5-113" }
+      end
+      describe security_policy do
+          its('SeDenyRemoteInteractiveLogonRight') { should include "S-1-5-114" }
+      end
+    end
+    describe security_policy do
+      its('SeDenyRemoteInteractiveLogonRight') { should include 'S-1-5-32-546' }
+    end
+  when '2'
+    describe security_policy do
+      its('SeDenyRemoteInteractiveLogonRight') { should eq ['S-1-5-32-546'] }
+    end
+  end
 end

--- a/controls/V-93009.rb
+++ b/controls/V-93009.rb
@@ -92,50 +92,48 @@ failover clustering."
   tag 'nist': ["AC-3", "Rev_4"]
 
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
-  is_domain = command('wmic computersystem get domain | FINDSTR /V Domain').stdout.strip
-  os_type = command('Test-Path "$env:windir\explorer.exe"').stdout.strip
-   if domain_role == '4' || domain_role == '5'
-      impact 0.0
-      desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
-        skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      end
-    elsif os_type == 'False'
-     describe 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt' do
-      skip 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt'
-     end
-    end 
-    if is_domain == 'WORKGROUP'
-        describe security_policy do
-         its('SeDenyNetworkLogonRight') { should eq ['S-1-5-32-546'] }
-        end
-    else
-      domain_query = <<-EOH
-              $group = New-Object System.Security.Principal.NTAccount('Domain Admins')
-              $sid = ($group.Translate([security.principal.securityidentifier])).value
-              $sid | ConvertTo-Json
-              EOH
-
-      domain_admin_sid = json(command: domain_query).params
-      enterprise_admin_query = <<-EOH
-              $group = New-Object System.Security.Principal.NTAccount('Enterprise Admins')
-              $sid = ($group.Translate([security.principal.securityidentifier])).value
-              $sid | ConvertTo-Json
-              EOH
-
-      enterprise_admin_sid = json(command: enterprise_admin_query).params
-       describe security_policy do
-          its('SeDenyNetworkLogonRight') { should include "#{domain_admin_sid}" }
-       end
-       describe security_policy do
-          its('SeDenyNetworkLogonRight') { should include "#{enterprise_admin_sid}" }
-       end
-       describe security_policy do
-          its('SeDenyNetworkLogonRight') { should include "S-1-5-113" }
-       end
-       describe security_policy do
-          its('SeDenyNetworkLogonRight') { should include "S-1-5-114" }
-       end
+  case domain_role
+  when '4', '5'
+    impact 0.0
+    desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
+    describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
+      skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
     end
-end
+  when '3'
+    domain_query = <<-EOH
+            $group = New-Object System.Security.Principal.NTAccount('Domain Admins')
+            $sid = ($group.Translate([security.principal.securityidentifier])).value
+            $sid | ConvertTo-Json
+            EOH
 
+    domain_admin_sid = json(command: domain_query).params
+    enterprise_admin_query = <<-EOH
+            $group = New-Object System.Security.Principal.NTAccount('Enterprise Admins')
+            $sid = ($group.Translate([security.principal.securityidentifier])).value
+            $sid | ConvertTo-Json
+            EOH
+
+    enterprise_admin_sid = json(command: enterprise_admin_query).params
+    describe security_policy do
+      its('SeDenyNetworkLogonRight') { should include "#{domain_admin_sid}" }
+    end
+    describe security_policy do
+      its('SeDenyNetworkLogonRight') { should include "#{enterprise_admin_sid}" }
+    end
+    describe.one do
+      describe security_policy do
+          its('SeDenyNetworkLogonRight') { should include "S-1-5-113" }
+      end
+      describe security_policy do
+          its('SeDenyNetworkLogonRight') { should include "S-1-5-114" }
+      end
+    end
+    describe security_policy do
+      its('SeDenyNetworkLogonRight') { should include 'S-1-5-32-546' }
+    end
+  when '2'
+    describe security_policy do
+      its('SeDenyNetworkLogonRight') { should eq ['S-1-5-32-546'] }
+    end
+  end
+end

--- a/controls/V-93013.rb
+++ b/controls/V-93013.rb
@@ -70,38 +70,37 @@ on as a service\" to include the following:
   tag 'nist': ["AC-3", "Rev_4"]
 
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
-  os_type = command('Test-Path "$env:windir\explorer.exe"').stdout.strip
-   if domain_role == '4' || domain_role == '5'
-      impact 0.0
-      desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
-        skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      end
-    elsif os_type == 'False'
-     describe 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt' do
-      skip 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt'
-     end
-   end 
-
-      domain_query = <<-EOH
+  case domain_role
+  when '4', '5'
+    impact 0.0
+    desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
+    describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
+      skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
+    end
+  when '3'
+    domain_query = <<-EOH
               $group = New-Object System.Security.Principal.NTAccount('Domain Admins')
               $sid = ($group.Translate([security.principal.securityidentifier])).value
               $sid | ConvertTo-Json
               EOH
 
-      domain_admin_sid = json(command: domain_query).params
-      enterprise_admin_query = <<-EOH
+    domain_admin_sid = json(command: domain_query).params
+    enterprise_admin_query = <<-EOH
               $group = New-Object System.Security.Principal.NTAccount('Enterprise Admins')
               $sid = ($group.Translate([security.principal.securityidentifier])).value
               $sid | ConvertTo-Json
               EOH
 
-      enterprise_admin_sid = json(command: enterprise_admin_query).params
-       describe security_policy do
-          its('SeDenyServiceLogonRight') { should include "#{domain_admin_sid}" }
-       end
-       describe security_policy do
-          its('SeDenyServiceLogonRight') { should include "#{enterprise_admin_sid}" }
-       end
+    enterprise_admin_sid = json(command: enterprise_admin_query).params
+    describe security_policy do
+      its('SeDenyServiceLogonRight') { should include "#{domain_admin_sid}" }
+    end
+    describe security_policy do
+      its('SeDenyServiceLogonRight') { should include "#{enterprise_admin_sid}" }
+    end
+  when '2'
+    describe security_policy do
+      its('SeDenyServiceLogonRight') { should be_empty }
+    end
+  end
 end
-

--- a/controls/V-93015.rb
+++ b/controls/V-93015.rb
@@ -74,44 +74,40 @@ on locally\" to include the following:
   tag 'nist': ["AC-3", "Rev_4"]
 
   domain_role = command('wmic computersystem get domainrole | Findstr /v DomainRole').stdout.strip
-  is_domain = command('wmic computersystem get domain | FINDSTR /V Domain').stdout.strip
-  os_type = command('Test-Path "$env:windir\explorer.exe"').stdout.strip
-   if domain_role == '4' || domain_role == '5'
-      impact 0.0
-      desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
-        skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
-      end
-    elsif os_type == 'False'
-     describe 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt' do
-      skip 'This system is a Server Core Installation, and a manual check will need to be performed with command Secedit /Export /Areas User_Rights /cfg c:\\path\\filename.txt'
-     end
-    end 
-    if is_domain == 'WORKGROUP'
-        describe security_policy do
-         its('SeDenyInteractiveLogonRight') { should eq ['S-1-5-32-546'] }
-        end
-    else
-      domain_query = <<-EOH
-              $group = New-Object System.Security.Principal.NTAccount('Domain Admins')
-              $sid = ($group.Translate([security.principal.securityidentifier])).value
-              $sid | ConvertTo-Json
-              EOH
-
-      domain_admin_sid = json(command: domain_query).params
-      enterprise_admin_query = <<-EOH
-              $group = New-Object System.Security.Principal.NTAccount('Enterprise Admins')
-              $sid = ($group.Translate([security.principal.securityidentifier])).value
-              $sid | ConvertTo-Json
-              EOH
-
-      enterprise_admin_sid = json(command: enterprise_admin_query).params
-       describe security_policy do
-          its('SeDenyInteractiveLogonRight') { should include "#{domain_admin_sid}" }
-       end
-       describe security_policy do
-          its('SeDenyInteractiveLogonRight') { should include "#{enterprise_admin_sid}" }
-       end
+  case domain_role
+  when '4', '5'
+    impact 0.0
+    desc 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
+    describe 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control' do
+      skip 'This system is dedicated to the management of Active Directory, therefore this system is exempt from this control'
     end
-end
+  when '2'
+    describe security_policy do
+      its('SeDenyInteractiveLogonRight') { should eq ['S-1-5-32-546'] }
+    end
+  when '3'
+    domain_query = <<-EOH
+            $group = New-Object System.Security.Principal.NTAccount('Domain Admins')
+            $sid = ($group.Translate([security.principal.securityidentifier])).value
+            $sid | ConvertTo-Json
+            EOH
 
+    domain_admin_sid = json(command: domain_query).params
+    enterprise_admin_query = <<-EOH
+            $group = New-Object System.Security.Principal.NTAccount('Enterprise Admins')
+            $sid = ($group.Translate([security.principal.securityidentifier])).value
+            $sid | ConvertTo-Json
+            EOH
+
+    enterprise_admin_sid = json(command: enterprise_admin_query).params
+    describe security_policy do
+      its('SeDenyInteractiveLogonRight') { should include "#{domain_admin_sid}" }
+    end
+    describe security_policy do
+      its('SeDenyInteractiveLogonRight') { should include "#{enterprise_admin_sid}" }
+    end
+    describe security_policy do
+      its('SeDenyInteractiveLogonRight') { should include 'S-1-5-32-546' }
+    end
+  end
+end


### PR DESCRIPTION
- controls are now skipped on domain controllers appropriately
```
↺  V-92965: Windows Server 2019 Deny log on through Remote Desktop Services user
  right on domain-joined member servers must be configured to prevent access from
  highly privileged domain accounts and all local accounts and from
  unauthenticated access on all systems.
     ↺  This system is dedicated to the management of Active Directory, therefore this system is exempt from this control
  ↺  V-93009: Windows Server 2019 Deny access to this computer from the network user
  right on domain-joined member servers must be configured to prevent access from
  highly privileged domain accounts and local accounts and from unauthenticated
  access on all systems.
     ↺  This system is dedicated to the management of Active Directory, therefore this system is exempt from this control
  ↺  V-93011: Windows Server 2019 Deny log on as a batch job user right on
  domain-joined member servers must be configured to prevent access from highly
  privileged domain accounts and from unauthenticated access on all systems.
     ↺  This system is dedicated to the management of Active Directory, therefore this system is exempt from this control
  ↺  V-93013: Windows Server 2019 Deny log on as a service user right on
  domain-joined member servers must be configured to prevent access from highly
  privileged domain accounts. No other groups or accounts must be assigned this
  right.
     ↺  This system is dedicated to the management of Active Directory, therefore this system is exempt from this control
  ↺  V-93015: Windows Server 2019 Deny log on locally user right on domain-joined
  member servers must be configured to prevent access from highly privileged
  domain accounts and from unauthenticated access on all systems.
     ↺  This system is dedicated to the management of Active Directory, therefore this system is exempt from this control
```
- controls apply to member servers that are configured per the STIG.
```
✔  V-92965: Windows Server 2019 Deny log on through Remote Desktop Services user
  right on domain-joined member servers must be configured to prevent access from
  highly privileged domain accounts and all local accounts and from
  unauthenticated access on all systems.
     ✔  Security Policy SeDenyRemoteInteractiveLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-512"
     ✔  Security Policy SeDenyRemoteInteractiveLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-519"
     ✔  Security Policy SeDenyRemoteInteractiveLogonRight is expected to include "S-1-5-113"
     ✔  Security Policy SeDenyRemoteInteractiveLogonRight is expected to include "S-1-5-32-546"
  ✔  V-93009: Windows Server 2019 Deny access to this computer from the network user
  right on domain-joined member servers must be configured to prevent access from
  highly privileged domain accounts and local accounts and from unauthenticated
  access on all systems.
     ✔  Security Policy SeDenyNetworkLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-512"
     ✔  Security Policy SeDenyNetworkLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-519"
     ✔  Security Policy SeDenyNetworkLogonRight is expected to include "S-1-5-113"
     ✔  Security Policy SeDenyNetworkLogonRight is expected to include "S-1-5-32-546"
  ✔  V-93011: Windows Server 2019 Deny log on as a batch job user right on
  domain-joined member servers must be configured to prevent access from highly
  privileged domain accounts and from unauthenticated access on all systems.
     ✔  Security Policy SeDenyBatchLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-512"
     ✔  Security Policy SeDenyBatchLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-519"
     ✔  Security Policy SeDenyBatchLogonRight is expected to include "S-1-5-32-546"
  ✔  V-93013: Windows Server 2019 Deny log on as a service user right on
  domain-joined member servers must be configured to prevent access from highly
  privileged domain accounts. No other groups or accounts must be assigned this
  right.
     ✔  Security Policy SeDenyServiceLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-512"
     ✔  Security Policy SeDenyServiceLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-519"
  ✔  V-93015: Windows Server 2019 Deny log on locally user right on domain-joined
  member servers must be configured to prevent access from highly privileged
  domain accounts and from unauthenticated access on all systems.
     ✔  Security Policy SeDenyInteractiveLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-512"
     ✔  Security Policy SeDenyInteractiveLogonRight is expected to include "S-1-5-21-2485657338-1484356311-222256282-519"
     ✔  Security Policy SeDenyInteractiveLogonRight is expected to include "S-1-5-32-546"
```
- the security_policy inspec resource works fine on ServerCore (my test system was not configured per the STIG) but I removed that skip logic.
```
  ×  V-92965: Windows Server 2019 Deny log on through Remote Desktop Services user
  right on domain-joined member servers must be configured to prevent access from
  highly privileged domain accounts and all local accounts and from
  unauthenticated access on all systems.
     ×  Security Policy SeDenyRemoteInteractiveLogonRight is expected to eq ["S-1-5-32-546"]
     
     expected: ["S-1-5-32-546"]
          got: []
     
     (compared using ==)

  ×  V-93009: Windows Server 2019 Deny access to this computer from the network user
  right on domain-joined member servers must be configured to prevent access from
  highly privileged domain accounts and local accounts and from unauthenticated
  access on all systems.
     ×  Security Policy SeDenyNetworkLogonRight is expected to eq ["S-1-5-32-546"]
     
     expected: ["S-1-5-32-546"]
          got: []
     
     (compared using ==)

  ×  V-93011: Windows Server 2019 Deny log on as a batch job user right on
  domain-joined member servers must be configured to prevent access from highly
  privileged domain accounts and from unauthenticated access on all systems.
     ×  Security Policy SeDenyBatchLogonRight is expected to eq ["S-1-5-32-546"]
     
     expected: ["S-1-5-32-546"]
          got: []
     
     (compared using ==)

  ✔  V-93013: Windows Server 2019 Deny log on as a service user right on
  domain-joined member servers must be configured to prevent access from highly
  privileged domain accounts. No other groups or accounts must be assigned this
  right.
     ✔  Security Policy SeDenyServiceLogonRight is expected to be empty
  ×  V-93015: Windows Server 2019 Deny log on locally user right on domain-joined
  member servers must be configured to prevent access from highly privileged
  domain accounts and from unauthenticated access on all systems.
     ×  Security Policy SeDenyInteractiveLogonRight is expected to eq ["S-1-5-32-546"]
     
     expected: ["S-1-5-32-546"]
          got: []
     
     (compared using ==)
```

These changes address the issues outlined in #22 